### PR TITLE
Error reporting typo fix in pack_libdevice.sh

### DIFF
--- a/include/qdp_dispatch.h
+++ b/include/qdp_dispatch.h
@@ -5,7 +5,6 @@
 #include "qdp_config.h"
 
 #if defined(QDP_USE_OMP_THREADS)
-#warning QDP using OpenMP threading
 #include <omp.h>
 namespace QDP {    
 /* OpenMP threading version of the dispatch.*/
@@ -42,7 +41,6 @@ void dispatch_to_threads(int numSiteTable, Arg a, void (*func)(int,int,int, Arg*
 #else 
 
 #if defined(QDP_USE_QMT_THREADS)
-#warning QDP using QMT threading
 
  /* QMT threading version of the dispatch. Call the qmt_call routine
      with userfunc, numSiteTable, and argument */

--- a/include/qdp_pete_visitors.h
+++ b/include/qdp_pete_visitors.h
@@ -72,6 +72,7 @@ struct AddressLeaf
   AddressLeaf& operator=(const AddressLeaf& cp) {
     assert(!"strange");
     addr = cp.addr;
+    return *this;
     //std::cout << "AddressLeaf assignment my_size = " << addr.size() << "\n";
   }
 

--- a/pack_libdevice.sh
+++ b/pack_libdevice.sh
@@ -22,7 +22,7 @@ if [ -f $OUT_LIB ]; then
 fi
 
 if [ ! -f ${LIBDEVICE_DIR}/libdevice.bc ]; then
-    echo "${LIBDEVICE_FILE}/libdevice.bc not found."
+    echo "${LIBDEVICE_DIR}/libdevice.bc not found."
     exit 1
 fi
 


### PR DESCRIPTION
Hi Frank, 
 I fixed a typo in this script. When the input file couldn't be found it always printed /libdevice.bc was not found as the parent path was LIBDEVICE_FILE rather than LIBDEVICE_DIR. Am I correct in understanding that because of CUDA-9 etc, we now always look for libdevice.bc (rather than say libdevice.10.bc)? This is fine and I am changing my scripts to build this. I am guessing pre CUDA-9 still works if I move the libdevice.compute.xx.bc to libdevice.bc right?

Thanks, B