### PR TITLE
Update from QDP++

### DIFF
--- a/examples/t_db.cc
+++ b/examples/t_db.cc
@@ -80,7 +80,7 @@ namespace Chroma
     const K& key() const {return key_;}
 
     // Part of Serializable
-    const unsigned short serialID (void) const {return 456;}
+    unsigned short serialID (void) const {return 456;}
 
     void writeObject (std::string& output) const throw (SerializeException) {
       BinaryBufferWriter bin;
@@ -127,7 +127,7 @@ namespace Chroma
     const D& data() const {return data_;}
 
     // Part of Serializable
-    const unsigned short serialID (void) const {return 123;}
+    unsigned short serialID (void) const {return 123;}
 
     void writeObject (std::string& output) const throw (SerializeException) {
       BinaryBufferWriter bin;

--- a/include/qdp_db_stub.h
+++ b/include/qdp_db_stub.h
@@ -42,18 +42,18 @@ namespace FILEDB
     /**
      * Get the serial id of this class
      */
-    virtual const unsigned short serialID (void) const = 0;
+    virtual unsigned short serialID (void) const = 0;
 
     /**
      * Return this object into a binary form
      */
-    virtual void writeObject (std::string& output) const throw (SerializeException) = 0;
+    virtual void writeObject (std::string& output) const = 0;
 
 
     /**
      * Convert input object retrieved from database or network into an object
      */
-    virtual void readObject (const std::string& input) throw (SerializeException) = 0;
+    virtual void readObject (const std::string& input) = 0;
 
 
   protected:
@@ -355,6 +355,28 @@ o     *
 	QDP_abort(1);
       }
   };
+
+  //--------------------------------------------------------------------------------
+  //!  Local DB Base class
+  /*!
+    This class is used for writing of user data (most usefully measurements)
+    into a DB file with a key/value semantics.
+    NOTE: NOT COLLECTIVE, all operations done on the scope of the current process.
+          Use BinaryStoreDB for a collective behaviour.
+  */
+  template <typename K, typename D>
+  class LocalBinaryStoreDB : public BinaryStoreDB<K, D>
+  {
+    /**
+     * Constructor
+     *
+     * @param do_init: whether to set cache
+     */
+    LocalBinaryStoreDB(bool = false)
+    {
+    }
+  };
+
 }  // namespace QDP
 
 #endif

--- a/include/qdp_default_allocator.h
+++ b/include/qdp_default_allocator.h
@@ -35,7 +35,7 @@ namespace QDP
       QDPDefaultAllocator() {init();}
       ~QDPDefaultAllocator() {}
 
-      friend struct QDP::CreateUsingNew<QDP::Allocator::QDPDefaultAllocator>;
+      friend struct QDP::SingletonHolder<QDP::Allocator::QDPDefaultAllocator>;
     public:
 
       // Pusher
@@ -62,18 +62,8 @@ namespace QDP
       void init();
     };
 
-    // Turn into a Singleton. Create with CreateUsingNew
-    // Has NoDestroy lifetime, as it may be needed for 
-    // the destruction policy is No Destroy, so the 
-    // Singleton is not cleaned up on exit. This is so 
-    // that static objects can refer to it with confidence
-    // in their own destruction, not having to worry that
-    // atexit() may have destroyed the allocator before
-    // the static objects need to feed memory. 
-    typedef SingletonHolder<QDP::Allocator::QDPDefaultAllocator,
-			    QDP::CreateUsingNew,
-			    QDP::NoDestroy,
-			    QDP::SingleThreaded> theQDPAllocator;
+    // Turn into a Singleton.
+    typedef SingletonHolder<QDP::Allocator::QDPDefaultAllocator> theQDPAllocator;
 
   } // namespace Allocator
 } // namespace QDP

--- a/include/qdp_singleton.h
+++ b/include/qdp_singleton.h
@@ -6,452 +6,49 @@
 #ifndef __qdp_singleton_h__
 #define __qdp_singleton_h__
 
-#include <algorithm>
-#include <stdexcept>
-#include <cassert>
-#include <cstdlib>
-#include <new>
-
 namespace QDP
 {
 
 ////////////////////////////////////////////////////////////////////////////////
-// class template SingleThreaded
-// Implementation of the ThreadingModel policy used by various classes
-// Implements a single-threaded model; no synchronization
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class Host>
-  class SingleThreaded
-  {
-  public:
-    struct Lock
-    {
-      Lock() {}
-      Lock(const Host&) {}
-    };
-        
-    typedef Host VolatileType;
-
-    typedef int IntType; 
-
-    static IntType AtomicAdd(volatile IntType& lval, IntType val)
-      { return lval += val; }
-        
-    static IntType AtomicSubtract(volatile IntType& lval, IntType val)
-      { return lval -= val; }
-
-    static IntType AtomicMultiply(volatile IntType& lval, IntType val)
-      { return lval *= val; }
-        
-    static IntType AtomicDivide(volatile IntType& lval, IntType val)
-      { return lval /= val; }
-        
-    static IntType AtomicIncrement(volatile IntType& lval)
-      { return ++lval; }
-        
-    static IntType AtomicDivide(volatile IntType& lval)
-      { return --lval; }
-        
-    static void AtomicAssign(volatile IntType & lval, IntType val)
-      { lval = val; }
-        
-    static void AtomicAssign(IntType & lval, volatile IntType & val)
-      { lval = val; }
-  };
-
-
-
-  namespace Private
-  {
-////////////////////////////////////////////////////////////////////////////////
-// class LifetimeTracker
-// Helper class for SetLongevity
-////////////////////////////////////////////////////////////////////////////////
-
-    class LifetimeTracker
-    {
-    public:
-      LifetimeTracker(unsigned int x) : longevity_(x) 
-	{}
-            
-      virtual ~LifetimeTracker() = 0;
-            
-      static bool Compare(const LifetimeTracker* lhs,
-			  const LifetimeTracker* rhs)
-	{
-	  return rhs->longevity_ > lhs->longevity_;
-	}
-            
-    private:
-      unsigned int longevity_;
-    };
-        
-    // Definition required
-    inline LifetimeTracker::~LifetimeTracker() {} 
-        
-    // Helper data
-    typedef LifetimeTracker** TrackerArray;
-    extern TrackerArray pTrackerArray;
-    extern unsigned int elements;
-
-    // Helper destroyer function
-    template <typename T>
-    struct Deleter
-    {
-      static void Delete(T* pObj)
-	{ delete pObj; }
-    };
-
-    // Concrete lifetime tracker for objects of type T
-    template <typename T, typename Destroyer>
-    class ConcreteLifetimeTracker : public LifetimeTracker
-    {
-    public:
-      ConcreteLifetimeTracker(T* p,unsigned int longevity, Destroyer d)
-	: LifetimeTracker(longevity)
-	, pTracked_(p)
-	, destroyer_(d)
-	{}
-            
-      ~ConcreteLifetimeTracker()
-	{ destroyer_(pTracked_); }
-            
-    private:
-      T* pTracked_;
-      Destroyer destroyer_;
-    };
-
-    void AtExitFn(); // declaration needed below
-    
-  } // namespace Private
-
-////////////////////////////////////////////////////////////////////////////////
-// function template SetLongevity
-// Assigns an object a longevity; ensures ordered destructions of objects 
-//     registered thusly during the exit sequence of the application
-////////////////////////////////////////////////////////////////////////////////
-
-  template <typename T, typename Destroyer>
-  void SetLongevity(T* pDynObject, unsigned int longevity,
-		    Destroyer d = Private::Deleter<T>::Delete)
-  {
-    using namespace Private;
-        
-    TrackerArray pNewArray = static_cast<TrackerArray>(
-      std::realloc(pTrackerArray, elements + 1));
-    if (!pNewArray) throw std::bad_alloc();
-        
-    LifetimeTracker* p = new ConcreteLifetimeTracker<T, Destroyer>(
-      pDynObject, longevity, d);
-        
-    // Delayed assignment for exception safety
-    pTrackerArray = pNewArray;
-        
-    // Insert a pointer to the object into the queue
-    TrackerArray pos = std::upper_bound(
-      pTrackerArray, 
-      pTrackerArray + elements, 
-      p, 
-      LifetimeTracker::Compare);
-    std::copy_backward(
-      pos, 
-      pTrackerArray + elements,
-      pTrackerArray + elements + 1);
-    *pos = p;
-    ++elements;
-        
-    // Register a call to AtExitFn
-    std::atexit(Private::AtExitFn);
-  }
-
-////////////////////////////////////////////////////////////////////////////////
-// class template CreateUsingNew
-// Implementation of the CreationPolicy used by SingletonHolder
-// Creates objects using a straight call to the new operator 
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T> struct CreateUsingNew
-  {
-    static T* Create()
-      { return new T; }
-        
-    static void Destroy(T* p)
-      { delete p; }
-  };
-    
-////////////////////////////////////////////////////////////////////////////////
-// class template CreateUsingNew
-// Implementation of the CreationPolicy used by SingletonHolder
-// Creates objects using a call to std::malloc, followed by a call to the 
-//     placement new operator
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T> struct CreateUsingMalloc
-  {
-    static T* Create()
-      {
-	void* p = std::malloc(sizeof(T));
-	if (!p) return 0;
-	return new(p) T;
-      }
-        
-    static void Destroy(T* p)
-      {
-	p->~T();
-	std::free(p);
-      }
-  };
-    
-////////////////////////////////////////////////////////////////////////////////
-// class template CreateStatic
-// Implementation of the CreationPolicy used by SingletonHolder
-// Creates an object in static memory
-// Implementation is slightly nonportable because it uses the MaxAlign trick 
-//     (an union of all types to ensure proper memory alignment). This trick is 
-//     nonportable in theory but highly portable in practice.
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T> struct CreateStatic
-  {
-    union MaxAlign
-    {
-      char t_[sizeof(T)];
-      short int shortInt_;
-      int int_;
-      long int longInt_;
-      float float_;
-      double double_;
-      long double longDouble_;
-      struct Test;
-      int Test::* pMember_;
-      int (Test::*pMemberFn_)(int);
-    };
-        
-    static T* Create()
-      {
-	static MaxAlign staticMemory_;
-	return new(&staticMemory_) T;
-      }
-        
-    static void Destroy(T* p)
-      {
-	p->~T();
-      }
-  };
-    
-////////////////////////////////////////////////////////////////////////////////
-// class template DefaultLifetime
-// Implementation of the LifetimePolicy used by SingletonHolder
-// Schedules an object's destruction as per C++ rules
-// Forwards to std::atexit
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T>
-  struct DefaultLifetime
-  {
-    static void ScheduleDestruction(T*, void (*pFun)())
-      { std::atexit(pFun); }
-        
-    static void OnDeadReference()
-      { throw std::logic_error("Dead Reference Detected"); }
-  };
-
-////////////////////////////////////////////////////////////////////////////////
-// class template PhoenixSingleton
-// Implementation of the LifetimePolicy used by SingletonHolder
-// Schedules an object's destruction as per C++ rules, and it allows object 
-//    recreation by not throwing an exception from OnDeadReference
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T>
-  class PhoenixSingleton
-  {
-  public:
-    static void ScheduleDestruction(T*, void (*pFun)())
-      {
-#ifndef ATEXIT_FIXED
-	if (!destroyedOnce_)
-#endif
-	  std::atexit(pFun);
-      }
-        
-    static void OnDeadReference()
-      {
-#ifndef ATEXIT_FIXED
-	destroyedOnce_ = true;
-#endif
-      }
-        
-  private:
-#ifndef ATEXIT_FIXED
-    static bool destroyedOnce_;
-#endif
-  };
-    
-#ifndef ATEXIT_FIXED
-  template <class T> bool PhoenixSingleton<T>::destroyedOnce_ = false;
-#endif
-        
-////////////////////////////////////////////////////////////////////////////////
-// class template Adapter
-// Helper for SingletonWithLongevity below
-////////////////////////////////////////////////////////////////////////////////
-
-  namespace Private
-  {
-    template <class T>
-    struct Adapter
-    {
-      void operator()(T*) { return pFun_(); }
-      void (*pFun_)();
-    };
-  }
-
-////////////////////////////////////////////////////////////////////////////////
-// class template SingletonWithLongevity
-// Implementation of the LifetimePolicy used by SingletonHolder
-// Schedules an object's destruction in order of their longevities
-// Assumes a visible function GetLongevity(T*) that returns the longevity of the
-//     object
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T>
-  class SingletonWithLongevity
-  {
-  public:
-    static void ScheduleDestruction(T* pObj, void (*pFun)())
-      {
-	Private::Adapter<T> adapter = { pFun };
-	SetLongevity(pObj, GetLongevity(pObj), adapter);
-      }
-        
-    static void OnDeadReference()
-      { throw std::logic_error("Dead Reference Detected"); }
-  };
-
-////////////////////////////////////////////////////////////////////////////////
-// class template NoDestroy
-// Implementation of the LifetimePolicy used by SingletonHolder
-// Never destroys the object
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T>
-  struct NoDestroy
-  {
-    static void ScheduleDestruction(T*, void (*)())
-      {}
-        
-    static void OnDeadReference()
-      {}
-  };
-
-////////////////////////////////////////////////////////////////////////////////
 // class template SingletonHolder
 // Provides Singleton amenities for a type T
-// To protect that type from spurious instantiations, you have to protect it
-//     yourself.
+// Please destroy the singleton when you pleased by calling `DestroySingleton`
 ////////////////////////////////////////////////////////////////////////////////
 
-  template <typename T,
-            template <class> class CreationPolicy = CreateUsingNew,
-            template <class> class LifetimePolicy = DefaultLifetime,
-            template <class> class ThreadingModel = SingleThreaded>
+  template <typename T>
   class SingletonHolder
   {
   public:
-    static T& Instance();
-        
+    static T& Instance()
+    {
+      return *getInstance(true);
+    }
+
+    static void DestroySingleton()
+    {
+      if (getInstance(false))
+      {
+	delete getInstance();
+	getInstance() = nullptr;
+      }
+    }
+
   private:
     // Helpers
-    static void MakeInstance();
-    static void DestroySingleton();
-        
+    static T*& getInstance(bool createNew = false)
+    {
+      static T* instance = nullptr;
+      if (!instance && createNew)
+	instance = new T;
+      return instance;
+    }
+
     // Protection
-    SingletonHolder();
-        
-    // Data
-    typedef typename ThreadingModel<T*>::VolatileType PtrInstanceType;
-    static PtrInstanceType pInstance_;
-    static bool destroyed_;
+    SingletonHolder()
+    {
+    }
   };
-    
-////////////////////////////////////////////////////////////////////////////////
-// SingletonHolder's data
-////////////////////////////////////////////////////////////////////////////////
 
-  template <class T,
-            template <class> class C,
-            template <class> class L,
-            template <class> class M>
-  typename SingletonHolder<T, C, L, M>::PtrInstanceType
-  SingletonHolder<T, C, L, M>::pInstance_;
-
-  template
-  <
-  class T,
-    template <class> class C,
-    template <class> class L,
-    template <class> class M
-  >
-  bool SingletonHolder<T, C, L, M>::destroyed_;
-
-////////////////////////////////////////////////////////////////////////////////
-// SingletonHolder::Instance
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T,
-            template <class> class CreationPolicy,
-            template <class> class LifetimePolicy,
-            template <class> class ThreadingModel>
-  inline T& SingletonHolder<T, CreationPolicy, 
-    LifetimePolicy, ThreadingModel>::Instance()
-  {
-    if (!pInstance_)
-    {
-      MakeInstance();
-    }
-    return *pInstance_;
-  }
-
-////////////////////////////////////////////////////////////////////////////////
-// SingletonHolder::MakeInstance (helper for Instance)
-////////////////////////////////////////////////////////////////////////////////
-
-  template <class T,
-            template <class> class CreationPolicy,
-            template <class> class LifetimePolicy,
-            template <class> class ThreadingModel>
-  void SingletonHolder<T, CreationPolicy, 
-    LifetimePolicy, ThreadingModel>::MakeInstance()
-  {
-    typename ThreadingModel<T>::Lock guard;
-    (void)guard;
-        
-    if (!pInstance_)
-    {
-      if (destroyed_)
-      {
-	LifetimePolicy<T>::OnDeadReference();
-	destroyed_ = false;
-      }
-      pInstance_ = CreationPolicy<T>::Create();
-      LifetimePolicy<T>::ScheduleDestruction(pInstance_, 
-					     &DestroySingleton);
-    }
-  }
-
-  template <class T,
-            template <class> class CreationPolicy,
-            template <class> class L,
-            template <class> class M>
-  void SingletonHolder<T, CreationPolicy, L, M>::DestroySingleton()
-  {
-    assert(!destroyed_);
-    CreationPolicy<T>::Destroy(pInstance_);
-    pInstance_ = 0;
-    destroyed_ = true;
-  }
 } // namespace Chroma
 
 

--- a/lib/qdp_byteorder.cc
+++ b/lib/qdp_byteorder.cc
@@ -7,170 +7,52 @@
 //     2  = little-endian (sun, ibm, hp, etc)
 //
 
+#include <iostream>
 #include <cstdlib>
 #include "qdp_byteorder.h"
 
 namespace QDPUtil
 {
-
-  using namespace std;
-
   //! Is the native byte order big endian?
   bool big_endian()
   {
-    union {
-      int  l;
-      char c[sizeof(int)];
-    } u;
-    u.l = 1;
-    return (u.c[sizeof(int) - 1] == 1);
+    int i = 1;
+    return (((char*)&i)[sizeof(int) - 1] == 1);
   }
 
-
   //! Byte-swap an array of data each of size nmemb
-  void byte_swap(void *ptr, size_t size, size_t nmemb)
+  // NOTE: p has no special alignment requirement
+  template <size_t size>
+  static void byte_swap(char* p, size_t nmemb)
   {
-    unsigned int j;
+    // Quick exit
+    if (size <= 1)
+      return;
 
-    char char_in[16];		/* characters used in byte swapping */
+    // Change the endianness
+    for (size_t i = 0; i < nmemb; i++)
+      for (size_t j = 0; j < size / 2; j++)
+	std::swap(p[i * size + j], p[i * size + size - 1 - j]);
+  }
 
-    char *in_ptr;
-    double *double_ptr;		/* Pointer used in the double routines */
-
-    switch (size)
+  void byte_swap(void* ptr, size_t size, size_t nmemb)
+  {
+    if (size == 1)
+      byte_swap<1>((char*)ptr, nmemb);
+    else if (size == 2)
+      byte_swap<2>((char*)ptr, nmemb);
+    else if (size == 4)
+      byte_swap<4>((char*)ptr, nmemb);
+    else if (size == 8)
+      byte_swap<8>((char*)ptr, nmemb);
+    else if (size == 16)
+      byte_swap<16>((char*)ptr, nmemb);
+    else
     {
-    case 4:  /* n_uint32_t */
-    {
-      n_uint32_t *w = (n_uint32_t *)ptr;
-      n_uint32_t old, recent;
-
-      for(j=0; j<nmemb; j++)
-      {
-	old = w[j];
-	recent = old >> 24 & 0x000000ff;
-	recent |= old >> 8 & 0x0000ff00;
-	recent |= old << 8 & 0x00ff0000;
-	recent |= old << 24 & 0xff000000;
-	w[j] = recent;
-      }
-    }
-    break;
-
-    case 1:  /* n_uint8_t: byte - do nothing */
-      break;
-
-    case 8:  /* n_uint64_t */
-    {
-      for(j = 0, double_ptr = (double *) ptr;
-	  j < nmemb;
-	  j++, double_ptr++)
-      {
-	in_ptr = (char *) double_ptr; /* Set the character pointer to
-					 point to the start of the double */
-
-	/*
-	 *  Assign all the byte variables to a character
-	 */
-	char_in[0] = in_ptr[0];
-	char_in[1] = in_ptr[1];
-	char_in[2] = in_ptr[2];
-	char_in[3] = in_ptr[3];
-	char_in[4] = in_ptr[4];
-	char_in[5] = in_ptr[5];
-	char_in[6] = in_ptr[6];
-	char_in[7] = in_ptr[7];
-
-	/*
-	 *  Now just swap the order
-	 */
-	in_ptr[0] = char_in[7];
-	in_ptr[1] = char_in[6];
-	in_ptr[2] = char_in[5];
-	in_ptr[3] = char_in[4];
-	in_ptr[4] = char_in[3];
-	in_ptr[5] = char_in[2];
-	in_ptr[6] = char_in[1];
-	in_ptr[7] = char_in[0];
-      }
-    }
-    break;
-
-    case 16:  /* Long Long */
-    {
-      for(j = 0, double_ptr = (double *) ptr;
-	  j < nmemb;
-	  j++, double_ptr+=2)
-      {
-
-	in_ptr = (char *) double_ptr; /* Set the character pointer to
-					 point to the start of the double */
-
-	/*
-	 *  Assign all the byte variables to a character
-	 */
-	char_in[0] = in_ptr[0];
-	char_in[1] = in_ptr[1];
-	char_in[2] = in_ptr[2];
-	char_in[3] = in_ptr[3];
-	char_in[4] = in_ptr[4];
-	char_in[5] = in_ptr[5];
-	char_in[6] = in_ptr[6];
-	char_in[7] = in_ptr[7];
-	char_in[8] = in_ptr[8];
-	char_in[9] = in_ptr[9];
-	char_in[10] = in_ptr[10];
-	char_in[11] = in_ptr[11];
-	char_in[12] = in_ptr[12];
-	char_in[13] = in_ptr[13];
-	char_in[14] = in_ptr[14];
-	char_in[15] = in_ptr[15];
-
-	/*
-	 *  Now just swap the order
-	 */
-	in_ptr[0] = char_in[15];
-	in_ptr[1] = char_in[14];
-	in_ptr[2] = char_in[13];
-	in_ptr[3] = char_in[12];
-	in_ptr[4] = char_in[11];
-	in_ptr[5] = char_in[10];
-	in_ptr[6] = char_in[9];
-	in_ptr[7] = char_in[8];
-
-	in_ptr[8] = char_in[7];
-	in_ptr[9] = char_in[6];
-	in_ptr[10] = char_in[5];
-	in_ptr[11] = char_in[4];
-	in_ptr[12] = char_in[3];
-	in_ptr[13] = char_in[2];
-	in_ptr[14] = char_in[1];
-	in_ptr[15] = char_in[0];
-
-      }
-    }
-    break;
-
-    case 2:  /* n_uint16_t */
-    {
-      n_uint16_t *w = (n_uint16_t *)ptr;
-      n_uint16_t old, recent;
-
-      for(j=0; j<nmemb; j++)
-      {
-	old = w[j];
-	recent = old >> 8 & 0x00ff;
-	recent |= old << 8 & 0xff00;
-	w[j] = recent;
-      }
-    }
-    break;
-
-    default:
-      fprintf(stderr,"%s: unsupported word size = %zu\n",__func__,size);
+      std::cerr << __func__ << ": unsupported word size = " << size << "\n";
       exit(1);
     }
   }
-
 
   //! fread on a binary file written in big-endian order
   size_t bfread(void *ptr, size_t size, size_t nmemb, FILE *stream)

--- a/lib/qdp_llvm.cc
+++ b/lib/qdp_llvm.cc
@@ -19,7 +19,7 @@
 #include "llvm/CodeGen/CommandFlags.h"
 using namespace llvm;
 using namespace llvm::codegen;
-#elif defined (QDP_LLVM8) || (QDP_LLVM9) || (QDP_LLVM10)
+#elif defined (QDP_LLVM8) || defined (QDP_LLVM9) || defined (QDP_LLVM10)
 #include "llvm/CodeGen/CommandFlags.inc"
 #else
 #include "llvm/CodeGen/CommandFlags.def"
@@ -1229,7 +1229,7 @@ namespace QDP {
       Builder.Inliner = llvm::createAlwaysInlinerLegacyPass();
     }
 
-#if defined (QDP_LLVM9) || (QDP_LLVM10) || (QDP_LLVM11)
+#if defined (QDP_LLVM9) || defined (QDP_LLVM10) || defined (QDP_LLVM11)
 #else
     Builder.DisableUnitAtATime = !UnitAtATime;
 #endif
@@ -1430,14 +1430,14 @@ namespace QDP {
 #endif
 
 
-#if defined (QDP_LLVM8) || (QDP_LLVM9) || (QDP_LLVM10) || (QDP_LLVM11)
+#if defined (QDP_LLVM8) || defined (QDP_LLVM9) || defined (QDP_LLVM10) || defined (QDP_LLVM11)
     std::string str;
     llvm::raw_string_ostream rss(str);
     llvm::buffer_ostream bos(rss);
     
     // Ask the target to add backend passes as necessary.
 
-#if defined (QDP_LLVM10) || (QDP_LLVM11)
+#if defined (QDP_LLVM10) || defined (QDP_LLVM11)
     if (target_machine->addPassesToEmitFile(PM, bos , nullptr ,  llvm::CGFT_AssemblyFile )) {
 #else
     if (target_machine->addPassesToEmitFile(PM, bos , nullptr ,  llvm::TargetMachine::CGFT_AssemblyFile )) {
@@ -1540,7 +1540,7 @@ namespace QDP {
 
     llvm::legacy::PassManager OurPM;
     OurPM.add( llvm::createInternalizePass( all_but_main ) );
-#if defined (QDP_LLVM8) || (QDP_LLVM9) || (QDP_LLVM10) || (QDP_LLVM11)
+#if defined (QDP_LLVM8) || defined (QDP_LLVM9) || defined (QDP_LLVM10) || defined (QDP_LLVM11)
     unsigned int sm_gpu = DeviceParams::Instance().getMajor() * 10 + DeviceParams::Instance().getMinor();
     OurPM.add( llvm::createNVVMReflectPass( sm_gpu ));
 #else

--- a/lib/qdp_parscalar_init.cc
+++ b/lib/qdp_parscalar_init.cc
@@ -650,6 +650,9 @@ namespace COUNT {
                 H5close();
 #endif
 
+		// Finalize pool allocator
+		Allocator::theQDPAllocator::DestroySingleton();
+
 		printProfile();
 		
 		QMP_finalize_msg_passing();

--- a/lib/qdp_parscalar_init.cc
+++ b/lib/qdp_parscalar_init.cc
@@ -61,9 +61,7 @@ namespace COUNT {
 	{{0,0}, {0,0}, {1,0},{0,0}},
 	{{0,0}, {0,0}, {0,0},{1,0}} } };
 
-
-
-  SpinMatrix QDP_Gamma_values[Ns*Ns];
+  SpinMatrix* QDP_Gamma_values = nullptr;
 
   extern SpinMatrix& Gamma(int i) {
     if (i<0 || i>15)
@@ -217,6 +215,7 @@ namespace COUNT {
     //QDP_info_primary("Finished setting gamma matrices");
     //QDP_info_primary("Multiplying gamma matrices");
 
+    QDP_Gamma_values = new SpinMatrix[Ns*Ns];
     QDP_Gamma_values[0]=dgr[4]; // Unity
     for (int i=1;i<16;i++) {
       zero_rep(QDP_Gamma_values[i]);
@@ -608,6 +607,9 @@ namespace COUNT {
 			QDP_abort(1);
 		}
 		
+		// Deallocate gammas
+		delete [] QDP_Gamma_values;
+
 		QDPIO::cout << "------------------\n";
 		QDPIO::cout << "-- JIT statistics:\n";
 		QDPIO::cout << "------------------\n";

--- a/lib/qdp_scalar_init.cc
+++ b/lib/qdp_scalar_init.cc
@@ -473,6 +473,9 @@ namespace COUNT {
                 H5close();
 #endif
 
+		// Finalize pool allocator
+		Allocator::theQDPAllocator::DestroySingleton();
+
 		printProfile();
 		
 		isInit = false;

--- a/lib/qdp_scalar_init.cc
+++ b/lib/qdp_scalar_init.cc
@@ -61,9 +61,7 @@ namespace COUNT {
 	{{0,0}, {0,0}, {1,0},{0,0}},
 	{{0,0}, {0,0}, {0,0},{1,0}} } };
 
-
-
-  SpinMatrix QDP_Gamma_values[Ns*Ns];
+  SpinMatrix* QDP_Gamma_values = nullptr;
 
   extern SpinMatrix& Gamma(int i) {
     if (i<0 || i>15)
@@ -180,6 +178,7 @@ namespace COUNT {
     //QDP_info_primary("Finished setting gamma matrices");
     //QDP_info_primary("Multiplying gamma matrices");
 
+    QDP_Gamma_values = new SpinMatrix[Ns*Ns];
     QDP_Gamma_values[0]=dgr[4]; // Unity
     for (int i=1;i<16;i++) {
       zero_rep(QDP_Gamma_values[i]);
@@ -450,6 +449,9 @@ namespace COUNT {
 			QDPIO::cerr << "QDP is not inited" << std::endl;
 			QDP_abort(1);
 		}
+		
+		// Deallocate gammas
+		delete [] QDP_Gamma_values;
 		
 		QDPIO::cout << "------------------\n";
 		QDPIO::cout << "-- JIT statistics:\n";

--- a/lib/qdp_scalarvec_init.cc
+++ b/lib/qdp_scalarvec_init.cc
@@ -80,6 +80,10 @@ bool QDP_isInitialized() {return isInit;}
 //! Turn off the machine
 void QDP_finalize()
 {
+
+  // Finalize pool allocator
+  Allocator::theQDPAllocator::DestroySingleton();
+
   printProfile();
 
   isInit = false;


### PR DESCRIPTION
- Replace byte_swap by a version without alignment requirements.
- Simplify SingletonHolder and force theQDPAllocator to be destroyed in QDP_finalize.
- Remove const from serialID and update filedb.
- Fix undefined behavior in MapObjectDisk: reading a different union member than the one set; only intel compiler 2019 without flag -align seems to cause the spoiling of the read and written objects.
- Add non-collective BinaryWriter and BinaryBufferWriter.