### PR TITLE
Removed duplicate qdp_llvm.cc from list of sources

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,7 +15,6 @@ add_library(qdp qdp_map.cc
  	qdp_stopwatch.cc
 	qdp_rannyu.cc
 	qdp_mapresource.cc
-	qdp_llvm.cc
 	qdp_cache.cc
 	qdp_mastermap.cc
 	qdp_masterset.cc


### PR DESCRIPTION
qdp_llvm.cc was listed in the source lists for both libqdp and libjit
I removed the one from libqdp since it links against libjit, and also
likely we want to compile it with C++-14.

This fixed an error (double free or corruption) on Summit at program exit
amongst the global destructors,  which arose from destroying the map  ptx_db::db when the -ptxdb option
was given. I am guessing the symbol was defined in both libjit and libqdp's qdp_llvm.o.
I am surprised that there was not a duplicate symbol issue at link time.

Best,
 B