### PR TITLE
Added include<unistd.h> for sleep()

### DIFF
--- a/include/qdp_jitf_eval.h
+++ b/include/qdp_jitf_eval.h
@@ -2,6 +2,7 @@
 #define QDP_JITFUNC_EVAL_H
 
 #include<type_traits>
+#include <unistd.h> // for sleep()
 
 namespace QDP {
 


### PR DESCRIPTION
Added 
```
#include <unistd.h>
```

for the `sleep()` call in `qdp_jitf_eval.h` not having it prevented compilation with hipcc on Crusher