### PR TITLE
Devel hotfix openmp needed

### DIFF
--- a/QDPXXConfig.cmake.in
+++ b/QDPXXConfig.cmake.in
@@ -145,9 +145,9 @@ if(@QDP_USE_HDF5@)
 endif()
 
 # OpenMP is always a dependency now
-if( NOT OpenMP_FOUND )
-  find_dependency(OpenMP REQUIRED)
-endif()
+#if( NOT OpenMP_FOUND )
+#  find_dependency(OpenMP REQUIRED)
+#endif()
 
 if(NOT Threads_FOUND )
   find_dependency(Threads REQUIRED)


### PR DESCRIPTION
It looks as though OpenMP is not actually needed (pragmas that are unsupported can be ignored). I fell afoul of this requirements check when working with an experimental compiler that does not use OpenMP
