### PR TITLE
Fix missing xml read/write functions for complex numbers

### DIFF
--- a/include/qdp_xmlio.h
+++ b/include/qdp_xmlio.h
@@ -13,6 +13,7 @@
 #include <list>
 #include <vector>
 #include <map>
+#include <complex>
 
 #include "xml_simplewriter.h"
 #include "basic_xpath_reader.h"
@@ -196,6 +197,10 @@ namespace QDP
   void read(XMLReader& xml, const std::string& s, double& input);
   //! Xpath query
   void read(XMLReader& xml, const std::string& s, bool& input);
+
+  //! Complex reader
+  void read(XMLReader& xml, const std::string& s, std::complex<float>& param);
+  void read(XMLReader& xml, const std::string& s, std::complex<double>& param);
 
 
   //! Read a XML multi1d element
@@ -723,6 +728,11 @@ namespace QDP
     \param output The  contents
   */
   void write(XMLWriter& xml, const std::string& s, const bool& output);
+
+  //! Complex writer
+  void write(XMLWriter& xml, const std::string& s, const std::complex<float>& param);
+  void write(XMLWriter& xml, const std::string& s, const std::complex<double>& param);
+  
 
   // Versions that do not print a name
   XMLWriter& operator<<(XMLWriter& xml, const std::string& output);

--- a/lib/qdp_xmlio.cc
+++ b/lib/qdp_xmlio.cc
@@ -306,6 +306,33 @@ namespace QDP
     xml.get(xpath, result);
   }
    
+  //! Complex reader
+  void read(XMLReader& xml, const std::string& xpath, std::complex<float>& param)
+  {
+    // NOTE: the C++-11 standard says a "real()" function returns a r-value - not an "l-value", so
+    // cannot simply read into a param.real()
+    XMLReader paramtop(xml, xpath);
+    
+    float re, im;
+    read(paramtop, "re", re);
+    read(paramtop, "im", im);
+    param = std::complex<float>(re,im);
+  }
+
+  
+  void read(XMLReader& xml, const std::string& xpath, std::complex<double>& param)
+  {
+    // NOTE: the C++-11 standard says a "real()" function returns a r-value - not an "l-value", so
+    // cannot simply read into a param.real()
+    XMLReader paramtop(xml, xpath);
+    
+    double re, im;
+    read(paramtop, "re", re);
+    read(paramtop, "im", im);
+    param = std::complex<double>(re,im);
+  }
+
+
 
   //! Read a XML multi1d element
   template<typename T>
@@ -883,6 +910,26 @@ namespace QDP
     xml << output.str();
     xml.closeTag();
   }
+
+
+  //! Complex writer
+  void write(XMLWriter& xml, const std::string& xpath, const std::complex<float>& param)
+  {
+    push(xml, xpath);
+    write(xml, "re", param.real());
+    write(xml, "im", param.imag());
+    pop(xml);
+  }
+
+  
+  void write(XMLWriter& xml, const std::string& xpath, const std::complex<double>& param)
+  {
+    push(xml, xpath);
+    write(xml, "re", param.real());
+    write(xml, "im", param.imag());
+    pop(xml);
+  }
+
 
 
   template<>


### PR DESCRIPTION
Bring the xml read/write functions for complex numbers from qdp++