### PR TITLE
Add libomptarget-amdgpu-ARCH.bc to vec_str_libdevice_name

### DIFF
--- a/lib/qdp_llvm.cc
+++ b/lib/qdp_llvm.cc
@@ -247,7 +247,7 @@ namespace QDP
 #ifdef QDP_BACKEND_ROCM
     std::vector<std::string> vec_str_libdevice_path = { ROCM_DIR };
     std::vector<std::string> vec_str_libdevice_path_append = { "llvm/lib/libdevice/" , "llvm/lib/" };
-    std::vector<std::string> vec_str_libdevice_name = { "libm-amdgcn-ARCH.bc" , "libomptarget-amdgcn-ARCH.bc" , "libomptarget-new-amdgpu-ARCH.bc" , "libomptarget-old-amdgpu-ARCH.bc" };
+    std::vector<std::string> vec_str_libdevice_name = { "libm-amdgcn-ARCH.bc" , "libomptarget-amdgpu-ARCH.bc", "libomptarget-amdgcn-ARCH.bc" , "libomptarget-new-amdgpu-ARCH.bc" , "libomptarget-old-amdgpu-ARCH.bc" };
 #elif QDP_BACKEND_CUDA
     std::vector<std::string> vec_str_libdevice_path = { "CUDAPATH" , "/usr/local/cuda/" , "/usr/lib/nvidia-cuda-toolkit/" };
     std::vector<std::string> vec_str_libdevice_path_append = { "nvvm/libdevice/" , "libdevice/" , "cuda/nvvm/libdevice/" , "cuda/CUDAVERSION/nvvm/libdevice/"};


### PR DESCRIPTION
As of ROCm 6.3 the name of the runtime library for OpenMP offload is libomptarget-amdgpu-ARCH.bc.
Therefore, adding it to the list of names to search for (vec_str_libdevice_name).
