### PR TITLE
Fix LLVM double linkage problem

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -97,7 +97,11 @@ target_include_directories( jit PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
         $<INSTALL_INTERFACE:include> )
 target_include_directories(jit PUBLIC ${LLVM_INCLUDE_DIRS} )
-target_link_libraries( jit PUBLIC ${LLVM_AVAILABLE_LIBS} )
+if( "LLVM" IN_LIST LLVM_AVAILABLE_LIBS )
+	target_link_libraries( jit PUBLIC LLVM )
+else()
+	target_link_libraries( jit PUBLIC ${LLVM_AVAILABLE_LIBS} )
+endif()
 target_link_libraries( jit PUBLIC QMP::qmp)
 
 if( QDP_ENABLE_BACKEND STREQUAL "ROCM" )


### PR DESCRIPTION
On some systems, for example the ones we have at the Supercomputing Center in Jülich (JSC), there is a system-wide distribution of LLVM (18.1.8 in our case). However, it is built using the flag `LLVM_BUILD_LLVM_DYLIB=ON`, which produces a shared library called just libLLVM.so that contains all modules.

The problem is that this library is added by CMake to the list `LLVM_AVAILABLE_LIBS` which is then used by this project to link libjit. This caues a fatal error at runtime because something in the initialization of the options passed to LLVM by QDP-JIT are parsed twice. Below is an example, but see also #23 
```
: CommandLine Error: Option 'experimental-debuginfo-iterators' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```

The suggested change in this PR fixes this problem by using only the shared LLVM library if it is present, which is the only thing that is needed, and the old method if not, so this won't break any existing builds.